### PR TITLE
default to instance iam role auth for accessing exhibitor_s3_bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installs and configures Zookeeper (managed with Exhibitor).
 
 ## Requirements and Dependencies
 
-Depends on a JRE (`playlist.java`).
+Depends on a JRE ([playlist.java](https://github.com/playlist-ansible/java)).
 
 ## Installation
 
@@ -37,8 +37,8 @@ exhibitor_port: 8181
 exhibitor_s3_bucket: mybucket
 exhibitor_s3_prefix: zookeeper
 exhibitor_s3_region: us-east-1
-exhibitor_s3_access_key_id: mykey
-exhibitor_s3_access_secret_key: mysecret
+#exhibitor_s3_access_key_id: mykey
+#exhibitor_s3_access_secret_key: mysecret
 
 exhibitor_log_index_directory: "{{zookeeper_log_dir}}"
 exhibitor_zookeeper_install_directory: "{{zookeeper_log_dir}}"
@@ -63,6 +63,16 @@ exhibitor_observer_threshold: 999
 exhibitor_auto_manage_instances_fixed_ensemble_size:
 exhibitor_auto_manage_instances_apply_all_at_once: 1
 ```
+
+If you want to use [key pair authentication](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
+when accessing `exhibitor_s3_bucket` define:
+
+```yaml
+exhibitor_s3_access_key_id: mykey
+exhibitor_s3_access_secret_key: mysecret
+```
+
+otherwise exhibitor will use [IAM role authentication](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,8 @@ exhibitor_port: 8181
 exhibitor_s3_bucket: mybucket
 exhibitor_s3_prefix: zookeeper
 exhibitor_s3_region: us-east-1
-exhibitor_s3_access_key_id: mykey
-exhibitor_s3_access_secret_key: mysecret
+#exhibitor_s3_access_key_id: mykey
+#exhibitor_s3_access_secret_key: mysecret
 
 exhibitor_log_index_directory: "{{zookeeper_log_dir}}"
 exhibitor_zookeeper_install_directory: "{{zookeeper_install_dir}}"

--- a/tasks/exhibitor.yml
+++ b/tasks/exhibitor.yml
@@ -45,7 +45,6 @@
     owner=zookeeper
     group=zookeeper
   with_items:
-    - credentials.properties
     - defaults.conf
     - log4j.properties
     - realm
@@ -55,11 +54,23 @@
   sudo: yes
   sudo_user: zookeeper
 
+- name: configure exhibitor s3 credentials
+  template: >
+    src={{item}}.j2
+    dest={{exhibitor_install_dir}}/credentials.properties
+    mode=0644
+    owner=zookeeper
+    group=zookeeper
+  notify:
+    - restart exhibitor
+  sudo: yes
+  sudo_user: zookeeper
+  when: >
+    exhibitor_s3_access_key_id is defined and
+    exhibitor_s3_access_secret_key is defined
+
 - name: add init script
   template: >
     src=exhibitor.init.j2
     dest=/etc/init.d/exhibitor
     mode=0755
-
-# - name: start exhibitor
-#   service: name=exhibitor state=started enabled=yes

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -4,7 +4,9 @@ EXHIBITOR_OPTS="--port {{exhibitor_port}}"
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --defaultconfig {{exhibitor_install_dir}}/defaults.conf"
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --configtype s3"
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3config \"{{exhibitor_s3_bucket}}:{{exhibitor_s3_prefix}}\""
-EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3credentials {{exhibitor_install_dir}}/credentials.properties"
+if [ -f "{{exhibitor_install_dir}}/credentials.properties" ] ; then
+    EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3credentials {{exhibitor_install_dir}}/credentials.properties"
+fi
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3region \"{{exhibitor_s3_region}}\""
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3backup true"
 {% if zookeeper_password %}


### PR DESCRIPTION
i think iam role auth is the standard way to auth from instances these days and is [supported by exhibitor](https://github.com/Netflix/exhibitor/issues/44). if :

```yaml
exhibitor_s3_access_key_id: mykey
exhibitor_s3_access_secret_key: mysecret
```

are defined `credentials.properties` is created as before and picked up by `start.sh`.
