### PR TITLE
allow none configtype for standalone testing other zookeeper clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,25 @@ language: python
 python: 2.7
 
 env:
-  - ANSIBLE_VERSION=1.9.4
-  - ANSIBLE_VERSION=2.0.0.2
+  matrix:
+  - ANSIBLE_VERSION=1.9.4   ANSIBLE_EXTRA_VARS='exhibitor_config_type=s3'
+  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS='exhibitor_config_type=s3'
+  - ANSIBLE_VERSION=1.9.4   ANSIBLE_EXTRA_VARS='exhibitor_config_type=none'
+  - ANSIBLE_VERSION=2.0.0.2 ANSIBLE_EXTRA_VARS='exhibitor_config_type=none'
 
 before_install:
   - sudo apt-get update -qq
 
 install:
   - pip install ansible==$ANSIBLE_VERSION
-  - "cp tests/ansible.cfg ansible.cfg"
-  - ansible-galaxy install -r tests/requirements.yml
+  - cd tests
+  - ansible-galaxy install -r requirements.yml
 
 script:
-  - "ansible-playbook -i tests/inventory tests/playbook.yml --syntax-check"
-  - "ansible-playbook -i tests/inventory tests/playbook.yml --connection=local --sudo"
+  - "ansible-playbook -i 'localhost,' playbook.yml --extra-vars=$ANSIBLE_EXTRA_VARS --syntax-check"
+  - "ansible-playbook -i 'localhost,' playbook.yml --extra-vars=$ANSIBLE_EXTRA_VARS --connection=local --sudo"
   - >
-    ansible-playbook -i tests/inventory tests/playbook.yml --connection=local --sudo
+    ansible-playbook -i 'localhost,' playbook.yml --extra-vars=$ANSIBLE_EXTRA_VARS --connection=local --sudo
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,11 +75,12 @@ Vagrant.configure(2) do |config|
     sudo apt-get update -qq
     sudo apt-get install python-dev python-pip -y
     sudo pip install ansible
+    rm -rf /tmp/zookeeper
     cp -R /vagrant /tmp/zookeeper
-    cd /tmp/zookeeper
-    cp tests/ansible.cfg ansible.cfg
-    ansible-galaxy install playlist.java
-    ansible-playbook -i tests/inventory tests/playbook.yml --syntax-check
-    ansible-playbook -i tests/inventory tests/playbook.yml --connection=local --sudo
+    cd /tmp/zookeeper/tests
+    ansible-galaxy install -r requirements.yml
+    ANSIBLE_EXTRA_VARS="exhibitor_config_type=none"
+    ansible-playbook -i "localhost," playbook.yml --extra-vars=$ANSIBLE_EXTRA_VARS --syntax-check
+    ansible-playbook -i "localhost," playbook.yml --extra-vars=$ANSIBLE_EXTRA_VARS --connection=local --sudo
   SHELL
 end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,11 +13,15 @@ exhibitor_install_dir: "/opt/exhibitor-{{exhibitor_version}}"
 exhibitor_log_dir: "{{zookeeper_log_dir}}"
 exhibitor_port: 8181
 
+exhibitor_config_type: s3
+
 exhibitor_s3_bucket: mybucket
 exhibitor_s3_prefix: zookeeper
 exhibitor_s3_region: us-east-1
 #exhibitor_s3_access_key_id: mykey
 #exhibitor_s3_access_secret_key: mysecret
+
+exhibitor_none_config_dir: /var/lib/exhibitor
 
 exhibitor_log_index_directory: "{{zookeeper_log_dir}}"
 exhibitor_zookeeper_install_directory: "{{zookeeper_install_dir}}"

--- a/tasks/exhibitor.yml
+++ b/tasks/exhibitor.yml
@@ -66,8 +66,20 @@
   sudo: yes
   sudo_user: zookeeper
   when: >
+    exhibitor_config_type == 's3' and
     exhibitor_s3_access_key_id is defined and
     exhibitor_s3_access_secret_key is defined
+
+- name: create exhibitor none config directory
+  file: >
+    path={{exhibitor_none_config_dir}}
+    state=directory
+    recurse=yes
+    owner=zookeeper
+    group=zookeeper
+  notify:
+    - restart exhibitor
+  when: exhibitor_config_type == 'none'
 
 - name: add init script
   template: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,8 @@
 ---
 - include: zookeeper.yml
+  tags:
+  - zookeeper
+
 - include: exhibitor.yml
+  tags:
+  - exhibitor

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -2,22 +2,31 @@
 
 EXHIBITOR_OPTS="--port {{exhibitor_port}}"
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --defaultconfig {{exhibitor_install_dir}}/defaults.conf"
-EXHIBITOR_OPTS="$EXHIBITOR_OPTS --configtype s3"
+EXHIBITOR_OPTS="$EXHIBITOR_OPTS --configtype {{exhibitor_config_type}}"
+{% if exhibitor_config_type == 'none' %}
+EXHIBITOR_OPTS="$EXHIBITOR_OPTS --noneconfigdir {{exhibitor_none_config_dir}}"
+{% endif %}
+{% if exhibitor_config_type == 's3' %}
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3config \"{{exhibitor_s3_bucket}}:{{exhibitor_s3_prefix}}\""
 if [ -f "{{exhibitor_install_dir}}/credentials.properties" ] ; then
     EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3credentials {{exhibitor_install_dir}}/credentials.properties"
 fi
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3region \"{{exhibitor_s3_region}}\""
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --s3backup true"
+{% endif %}
 {% if zookeeper_password %}
 EXHIBITOR_OPTS="$EXHIBITOR_OPTS --security web.xml --realm Zookeeper:realm --remoteauth basic:zk"
 {% endif %}
 
+{% if exhibitor_config_type == 's3' %}
 if [ -f "/usr/bin/ec2metadata" ] ; then
   OS_HOSTNAME=$(ec2metadata --public-hostname)
 else
   OS_HOSTNAME=$(hostname -f)
 fi
+{% else %}
+OS_HOSTNAME=$(hostname -f)
+{% endif %}
 
 cd {{exhibitor_install_dir}}
 HOSTNAME=${EXHIBITOR_HOSTNAME:-$OS_HOSTNAME}

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-roles_path = ../
+roles_path = ../../

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost


### PR DESCRIPTION
wanted to use this w/ local testing (so w/o s3) of https://github.com/jaytaylor/ansible-kafka